### PR TITLE
Eliminate warning: ignoring return value of getcwd.

### DIFF
--- a/src/stdlib.cpp
+++ b/src/stdlib.cpp
@@ -2711,11 +2711,12 @@ lk_string lk::get_cwd()
 {
 	char buf[2048];
 #ifdef _WIN32
-	::GetCurrentDirectoryA(2047, buf);
+	if (::GetCurrentDirectoryA(sizeof(buf), buf) == 0)
+	  return lk_string();
 #else
-	::getcwd(buf, 2047);
+	if (::getcwd(buf, sizeof(buf)) == NULL)
+	  return lk_string();
 #endif
-	buf[2047] = 0;
 	return lk_string(buf);
 }
 


### PR DESCRIPTION
This patch eliminates the one warning when building on Linux.  Hopefully this version is a bit cleaner and more robust. There was never any need to place a null termination character in buf[2047].

* src/stdlib.cpp (get_cwd): Use sizeof() instead of hardcoded values
  for the size of the buffer. If getcwd() (or its Win32 counterpart)
  returns NULL, return an empty string.