### PR TITLE
Add a .travis.yml file for continuous integration via Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: c++
+before_script:
+  - wget -q https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.0/wxWidgets-3.1.0.tar.bz2
+  - tar jxf wxWidgets-3.1.0.tar.bz2
+  - (cd wxWidgets-3.1.0 && ./configure --prefix=$HOME/wx-3.1.0 && make -j2 all install)
+  - ln -s $HOME/wx-3.1.0/bin/wx-config $HOME/wx-3.1.0/bin/wx-config-3
+
+script:
+  - export PATH=$PATH:$HOME/wx-3.1.0/bin
+  - make -j2 -C build_linux
+
+install:
+  - sudo apt-get install -y libgtk-3-dev


### PR DESCRIPTION
This is a working .travis.yml file that can be used with Travis CI for continuous integration builds and testing.  At the moment, warnings are not picked up, but could be if -Werror is included in CXXFLAGS.