### PR TITLE
* build_linux/Makefile: Enable -Werror.

### DIFF
--- a/build_linux/Makefile
+++ b/build_linux/Makefile
@@ -1,7 +1,8 @@
 VPATH = ../src
 CC = gcc
 CXX = g++
-CFLAGS = -I../include -fPIC -Wall -O2 -DLK_USE_WXWIDGETS `wx-config-3 --cflags`
+WARNINGS = -Wall -Werror
+CFLAGS = -I../include -fPIC $(WARNINGS) -O2 -DLK_USE_WXWIDGETS `wx-config-3 --cflags`
 CXXFLAGS = -std=c++0x $(CFLAGS)
 #CXXFLAGS= -std=c++11 $(CFLAGS)
 #OBJCXXFLAGS=-stdlib=libc++ -std=c++11


### PR DESCRIPTION
Now that there are zero warnings in the Linux build, we should turn on -Werror!