### PR TITLE
 Remove deprecated wxWidgets method wxCodeEditControl::SetStyleBits

### DIFF
--- a/sandbox/sandbox.cpp
+++ b/sandbox/sandbox.cpp
@@ -165,7 +165,6 @@ public:
 
         m_code->SetScrollWidthTracking(true);
 
-        m_code->SetStyleBits(8);
         m_code->SetLayoutCache(wxSTC_CACHE_PAGE);
         m_code->SetLexer(wxSTC_LEX_NULL);
 


### PR DESCRIPTION
This patch removes a call to a deprecated wxWidgets method, `wxCodeEditControl::SetStyleBits`. According to my reading of the wxWidgets and Scintilla manuals, we can just do away with this without any other changes. A similar pull request as been made foir [WEX](https://github.com/NREL/wex/pull/102).

G++ `-Wall` warns around deprecated functions and so this was warning.