### PR TITLE
Allow building core LK engine without wxWidgets

### DIFF
--- a/include/lk/absyn.h
+++ b/include/lk/absyn.h
@@ -54,12 +54,41 @@ typedef wxStringEqual lk_string_equal;
 
 #else
 #include <string>
+#include <sstream>
 
 typedef std::string::value_type lk_char;
 typedef std::string lk_string;
 
 typedef std::hash<std::string> lk_string_hash;
 typedef std::equal_to<std::string> lk_string_equal;
+
+inline lk_string& operator << (lk_string& a, const lk_string& lstr)
+{
+    a += lstr;
+    return a;
+}
+
+inline lk_string& operator << (lk_string& a, const char* s)
+{
+    a += s;
+    return a;
+}
+
+inline lk_string& operator << (lk_string& a, int i)
+{
+    std::stringstream sstr;
+    sstr << i;
+    a += sstr.str();
+    return a;
+}
+
+inline lk_string& operator << (lk_string& a, size_t i)
+{
+    std::stringstream sstr;
+    sstr << i;
+    a += sstr.str();
+    return a;
+}
 
 #endif
 

--- a/include/lk/stdlib.h
+++ b/include/lk/stdlib.h
@@ -25,7 +25,9 @@
 #ifndef __lk_stdlib_h
 #define __lk_stdlib_h
 
+#ifdef LK_USE_WXWIDGETS
 #include <wx/wx.h>
+#endif
 
 #include <lk/env.h>
 
@@ -162,6 +164,8 @@ namespace lk {
     double erfc(double x);
 };
 
+#ifdef LK_USE_WXWIDGETS
+
 class MyMessageDialog : public wxDialog {
 public:
     MyMessageDialog(wxWindow *parent,
@@ -254,5 +258,6 @@ DECLARE_EVENT_TABLE();
 };
 
 wxWindow *GetCurrentTopLevelWindow();
+#endif
 
 #endif

--- a/src/stdlib.cpp
+++ b/src/stdlib.cpp
@@ -4100,6 +4100,7 @@ double lk::erfc(double x) {
     return x < 0.0 ? 1.0 + gammp(0.5, x * x) : gammq(0.5, x * x);
 }
 
+#ifdef LK_USE_WXWIDGETS
 wxWindow *GetCurrentTopLevelWindow() {
     wxWindowList &wl = ::wxTopLevelWindows;
     for (wxWindowList::iterator it = wl.begin(); it != wl.end(); ++it)
@@ -4109,6 +4110,7 @@ wxWindow *GetCurrentTopLevelWindow() {
 
     return 0;
 }
+#endif
 
 #ifdef WIN32
 


### PR DESCRIPTION
Currently, code LK engine doesn't build if wxWidgets is not used (`LK_USE_WXWIDGETS` not defined). This is caused by some wxwidgets related code that doesn't reside inside ifdef/endif `LK_USE_WXWIDGETS` and missing `<<` operators for `lk_string` type.

This PR fixes this by adding ifdef/endif `LK_USE_WXWIDGETS` around wxWidgets code and implementing `<< `operators for `lk_string` type when `LK_USE_WXWIDGETS` is not defined.