### PR TITLE
Update address of license to NatLabRockies

### DIFF
--- a/sandbox/sandbox.cpp
+++ b/sandbox/sandbox.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/lk/blob/develop/LICENSE 
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/lk/blob/develop/LICENSE 
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/src/absyn.cpp
+++ b/src/absyn.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/lk/blob/develop/LICENSE 
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/lk/blob/develop/LICENSE 
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/lk/blob/develop/LICENSE 
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/lk/blob/develop/LICENSE 
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/lk/blob/develop/LICENSE 
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/lk/blob/develop/LICENSE 
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/lk/blob/develop/LICENSE 
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/lk/blob/develop/LICENSE 
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/src/invoke.cpp
+++ b/src/invoke.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/lk/blob/develop/LICENSE 
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/lk/blob/develop/LICENSE 
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/src/lex.cpp
+++ b/src/lex.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/lk/blob/develop/LICENSE 
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/lk/blob/develop/LICENSE 
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/lk/blob/develop/LICENSE 
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/lk/blob/develop/LICENSE 
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/src/stdlib.cpp
+++ b/src/stdlib.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/lk/blob/develop/LICENSE 
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/lk/blob/develop/LICENSE 
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/lk/blob/develop/LICENSE 
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/lk/blob/develop/LICENSE 
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
Updates the Github license URL to reference NatLabRockies as the organization.

There are PR's for all other repos from branches by the same name, but this one can be merged independently as these updates only affect comments.